### PR TITLE
fix: added docker-compose.yml for running keyclock container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  keycloak:
+    image: quay.io/keycloak/keycloak:19.0.1
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    command:
+      [
+        'start-dev'
+      ]
+    ports:
+      - 8080:8080


### PR DESCRIPTION
this resolves #2 

hit docker compose up command in the root directory to run keyclock container locally.

![image](https://github.com/user-attachments/assets/dd05d62c-fb0a-4945-8d46-a67732d777b2)
![image](https://github.com/user-attachments/assets/1d342953-8b40-4262-b82e-9dde48ee4749)
